### PR TITLE
#162532293: Create and Test API endpoints for updating record status

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Deletes an existing red flag record
 
 
 
-#### Update Comment Red Flag Record
+#### Update Comment of Red Flag Record
 Updates the comment of an existing red flag record
 
 * **URL**
@@ -582,7 +582,7 @@ Updates the comment of an existing red flag record
   
     (One of)  
     
-    - `"You do not have permissions to delete this record"`
+    - `"You do not have permissions to update the comment of this record"`
     
     - `"Request has no Token, Please Login or SignUp"`
     
@@ -680,7 +680,7 @@ Updates the location of an existing red flag record
 
     (One of)
 
-    - `"You do not have permissions to delete this record"`
+    - `"You do not have permissions to update the location of this record"`
 
     - `"Request has no Token, Please Login or SignUp"`
 
@@ -701,6 +701,107 @@ Updates the location of an existing red flag record
         data: {
             latitude: "3.4433",
             longitude: "14.2",
+        }
+    }).done(() => {
+        //Do something with data
+       });
+  ```
+
+
+
+#### Update Status of Red Flag Record
+Updates the status of an existing Red Flag record
+
+* **URL**
+  ##### Online 
+    https://sans-stitches.herokuapp.com/api/v1/red-flags/:red-flag-id/status
+
+  ##### Locally
+    http://localhost:4000/api/v1/red-flags/:red-flag-id/status
+
+* **Method:**
+
+  `PATCH`
+  
+* **Headers Required**
+
+  `Authorization= "Bearer " + token`
+
+* **URL Params**
+
+    **Required:**
+    
+    `red-flag-id=[integer]`
+
+* **Data Params**
+
+    **Required:**
+    
+    `status=[string]`
+    
+    **Not Required:**
+    
+    `feedback=[string]`    
+
+* **Success Response:**
+
+  * **status:** 200
+  
+  * **data:** `[ {`
+  
+    `id: <Id of updated record>`, 
+    
+    `message : "Updated intervention record’s status to " + <status-passed>`, 
+    
+    `updatedRecord: {<Udpated Record>}`
+    
+    `} ]`
+
+* **Error Responses:**
+
+  * **status:** 400 BAD REQUEST
+  
+  * **error:** `[`
+  
+    (One of)
+    
+    - `{ status: "Status is Required" } `
+    
+    - `{ status: "Invalid Status" }`
+
+    - `{ feedback: "Invalid Feedback" }`
+    
+    `]`
+    
+   OR
+
+  * **status:** 403 FORBIDDEN
+
+  * **error:** 
+
+    (One of)
+
+    - `"You do not have permissions to update the status of this record"`
+
+    - `"Request has no Token, Please Login or SignUp"`
+
+ OR
+
+  * **status:** 404 NOT FOUND
+
+  * **error:** `"Record does not exist"`
+
+* **Sample Call:**
+  ```javascript
+    $.ajax({
+        url: "https://sans-stitches.herokuapp.com/api/v1/red-flags/3/status",
+        method: "PATCH",
+        headers: {
+            "authorization": "Bearer " + token;
+        },
+        data: {
+            status: "resolved",
+            feedback: "Thanks to you the senator will not be embezzling public funds anymore",
         }
     }).done(() => {
         //Do something with data
@@ -993,7 +1094,7 @@ Deletes an existing intervention record
 
 
 
-#### Update Comment Intervention Record
+#### Update Comment of Intervention Record
 Updates the comment of an existing Intervention record
 
 * **URL**
@@ -1063,7 +1164,7 @@ Updates the comment of an existing Intervention record
   
     (One of)  
     
-    - `"You do not have permissions to delete this record"`
+    - `"You do not have permissions to update the comment of this record"`
     
     - `"Request has no Token, Please Login or SignUp"`
     
@@ -1161,7 +1262,7 @@ Updates the location of an existing Intervention record
 
     (One of)
 
-    - `"You do not have permissions to delete this record"`
+    - `"You do not have permissions to update the location of this record"`
 
     - `"Request has no Token, Please Login or SignUp"`
 
@@ -1182,6 +1283,107 @@ Updates the location of an existing Intervention record
         data: {
             latitude: "3.4433",
             longitude: "14.2",
+        }
+    }).done(() => {
+        //Do something with data
+       });
+  ```
+
+
+
+#### Update Status of Intervention Record
+Updates the status of an existing Intervention record
+
+* **URL**
+  ##### Online 
+    https://sans-stitches.herokuapp.com/api/v1/interventions/:intervention-id/status
+
+  ##### Locally
+    http://localhost:4000/api/v1/interventions/:intervention-id/status
+
+* **Method:**
+
+  `PATCH`
+  
+* **Headers Required**
+
+  `Authorization= "Bearer " + token`
+
+* **URL Params**
+
+    **Required:**
+    
+    `intervention-id=[integer]`
+
+* **Data Params**
+
+    **Required:**
+    
+    `status=[string]`
+    
+    **Not Required:**
+    
+    `feedback=[string]`    
+
+* **Success Response:**
+
+  * **status:** 200
+  
+  * **data:** `[ {`
+  
+    `id: <Id of updated record>`, 
+    
+    `message : "Updated intervention record’s status to " + <status-passed>`, 
+    
+    `updatedRecord: {<Udpated Record>}`
+    
+    `} ]`
+
+* **Error Responses:**
+
+  * **status:** 400 BAD REQUEST
+  
+  * **error:** `[`
+  
+    (One of)
+    
+    - `{ status: "Status is Required" } `
+    
+    - `{ status: "Invalid Status" }`
+
+    - `{ feedback: "Invalid Feedback" }`
+    
+    `]`
+    
+   OR
+
+  * **status:** 403 FORBIDDEN
+
+  * **error:** 
+
+    (One of)
+
+    - `"You do not have permissions to update the status of this record"`
+
+    - `"Request has no Token, Please Login or SignUp"`
+
+ OR
+
+  * **status:** 404 NOT FOUND
+
+  * **error:** `"Record does not exist"`
+
+* **Sample Call:**
+  ```javascript
+    $.ajax({
+        url: "https://sans-stitches.herokuapp.com/api/v1/interventions/3/status",
+        method: "PATCH",
+        headers: {
+            "authorization": "Bearer " + token;
+        },
+        data: {
+            status: "rejected",
+            feedback: "Weak supporting evidence",
         }
     }).done(() => {
         //Do something with data

--- a/server/controllers/recordsController.js
+++ b/server/controllers/recordsController.js
@@ -136,10 +136,11 @@ const controller = {
     if (!req.user.is_admin) {
       return res.json(notAuthorized('update the status of'));
     }
+    const feedback = (req.body.feedback) ? req.body.feedback : specificRecord.feedback;
     const updatedRecordParams = [
       specificRecordId, specificRecord.comment, specificRecord.description,
       specificRecord.location, req.body.status,
-      specificRecord.feedback, specificRecord.images, specificRecord.videos,
+      feedback, specificRecord.images, specificRecord.videos,
     ];
     const scndDbResponse = await db.sendQuery(queries.updateRecordQuery(), updatedRecordParams);
     const updatedRecord = scndDbResponse.rows[0];

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -22,12 +22,11 @@ const controller = {
       names[names.length - 1],
       names.slice(1, names.length - 1).join(' '),
       password,
-      false,
       phoneNumber,
       new Date(),
       email,
     ];
-    const scndDbResponse = await db.sendQuery(queries.addUserQuery(), userParams);
+    const scndDbResponse = await db.sendQuery(queries.addNonAdminQuery(), userParams);
     const user = scndDbResponse.rows[0];
     const token = await tokenizer.createToken(user);
     return res.json({

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -100,6 +100,21 @@ const validator = {
     const validationMessageArr = validateLatitudeAndLongitude(latitude, longitude, true);
     return (validationMessageArr.length) ? res.json(invalidField(validationMessageArr)) : next();
   },
+  validateStatus: (req, res, next) => {
+    const {
+      status,
+      feedback,
+    } = req.body;
+    const validationMessageArr = [];
+    if (!status || (typeof status === 'string' && !status.trim())) {
+      validationMessageArr.push({ status: 'Status is Required' });
+    } if (typeof status !== 'string') {
+      validationMessageArr.push({ status: 'Invalid Status' });
+    } if (feedback && typeof feedback !== 'string') {
+      validationMessageArr.push({ feedback: 'Invalid Feedback' });
+    }
+    return (validationMessageArr.length) ? res.json(invalidField(validationMessageArr)) : next();
+  },
 };
 
 export default validator;

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -105,10 +105,11 @@ const validator = {
       status,
       feedback,
     } = req.body;
+    const acceptableStatusVals = ['pending review', 'under investigation', 'rejected', 'resolved'];
     const validationMessageArr = [];
     if (!status || (typeof status === 'string' && !status.trim())) {
       validationMessageArr.push({ status: 'Status is Required' });
-    } if (typeof status !== 'string') {
+    } if (typeof status !== 'string' || acceptableStatusVals.indexOf(status) === -1) {
       validationMessageArr.push({ status: 'Invalid Status' });
     } if (feedback && typeof feedback !== 'string') {
       validationMessageArr.push({ feedback: 'Invalid Feedback' });

--- a/server/routes/intervention.js
+++ b/server/routes/intervention.js
@@ -11,5 +11,6 @@ interventionRouter.post('/', tokenizer.verifyToken, validator.validateRecord, re
 interventionRouter.delete('/:id', tokenizer.verifyToken, recordsController.deleteInterventionRecord);
 interventionRouter.patch('/:id/location', tokenizer.verifyToken, validator.validateGeolocation, recordsController.updateInterventionRecordLocation);
 interventionRouter.patch('/:id/comment', tokenizer.verifyToken, validator.validateRecord, recordsController.updateInterventionRecordComment);
+interventionRouter.patch('/:id/status', tokenizer.verifyToken, validator.validateStatus, recordsController.updateInterventionRecordStatus);
 
 export default interventionRouter;

--- a/server/routes/red-flag.js
+++ b/server/routes/red-flag.js
@@ -11,5 +11,6 @@ redFlagRouter.post('/', tokenizer.verifyToken, validator.validateRecord, records
 redFlagRouter.delete('/:id', tokenizer.verifyToken, recordsController.deleteRedFlagRecord);
 redFlagRouter.patch('/:id/location', tokenizer.verifyToken, validator.validateGeolocation, recordsController.updateRedFlagRecordLocation);
 redFlagRouter.patch('/:id/comment', tokenizer.verifyToken, validator.validateRecord, recordsController.updateRedFlagRecordComment);
+redFlagRouter.patch('/:id/status', tokenizer.verifyToken, validator.validateStatus, recordsController.updateRedFlagRecordStatus);
 
 export default redFlagRouter;

--- a/server/store/initTables.js
+++ b/server/store/initTables.js
@@ -1,20 +1,18 @@
 import db from './db';
 import queries from './queries';
 
+const testEmails = ['jackieboy@yahoo.com', 'jackiechanizzle@yahoo.com', 'damo@yahoo.com',
+  'moses@yahoo.com', 'duplicationtestemail@yahoo.com', 'mainaki@yahoo.com'];
+
+
 const dbTables = {
-  create: () => new Promise((resolve, reject) => {
-    db.sendQuery(queries.createRecordsTableQuery())
-      .then(() => db.sendQuery(queries.createUsersTableQuery()))
-      .then(resp => resolve(resp))
-      .catch(err => reject(err));
-  }),
-  drop: () => new Promise((resolve, reject) => {
-    db.sendQuery(queries.dropRecordsTableQuery())
-      .then(() => db.sendQuery(queries.dropUsersTableQuery()))
-      .then(resp => resolve(resp))
-      .catch(err => reject(err));
-  }),
+  deleteTestEmails: () => Promise.all(
+    testEmails.map(email => db.sendQuery(queries.deleteUserByEmailQuery(), [email])),
+  ).then(() => dbTables.addAdminUser()),
+  addAdminUser: () => db.sendQuery(queries.addAdminQuery(), [
+    'admin@yahoo.com', 'admin', 'boss', 'olowo',
+    'baddestadmineverliveth', '0908345768943', new Date(),
+    'admin@yahoo.com']).then(resp => Promise.resolve(resp)),
 };
 
-dbTables.drop()
-  .then(() => dbTables.create());
+dbTables.deleteTestEmails();

--- a/server/store/queries.js
+++ b/server/store/queries.js
@@ -1,47 +1,21 @@
 export default {
-  createUsersTableQuery: () => `CREATE TABLE IF NOT EXISTS
-  users(
-    id SERIAL PRIMARY KEY,
-    email VARCHAR(128) NOT NULL,
-    firstname VARCHAR(128) NOT NULL,
-    lastname VARCHAR(128),
-    othername VARCHAR(128),
-    password VARCHAR(128) NOT NULL,
-    is_admin BOOL,
-    phone_number VARCHAR(128),
-    registered TIMESTAMP,
-    username VARCHAR(128)
-    )`,
-
-  dropUsersTableQuery: () => 'DROP TABLE IF EXISTS users',
-
   getUserByEmailAndPasswordQuery: () => `SELECT * from users 
   WHERE email=$1 and password=$2`,
 
   getUserByEmailQuery: () => `SELECT * from users 
   WHERE email=$1`,
 
-  addUserQuery: () => `INSERT INTO 
-  users(email,firstname,lastname,othername,password,is_admin,phone_number,registered,username)
-  VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9)
+  deleteUserByEmailQuery: () => 'DELETE from users WHERE email=$1',
+
+  addNonAdminQuery: () => `INSERT INTO 
+  users(email,firstname,lastname,othername,password,phone_number,registered,username,is_admin)
+  VALUES($1,$2,$3,$4,$5,$6,$7,$8,false)
   returning *`,
 
-  createRecordsTableQuery: () => `CREATE TABLE IF NOT EXISTS
-  records(
-    id SERIAL PRIMARY KEY,
-    comment VARCHAR(128) NOT NULL,
-    description VARCHAR(128),
-    type VARCHAR(128),
-    created_on TIMESTAMP,
-    created_by INT NOT NULL,
-    location VARCHAR(128),
-    is_active BOOL,
-    status VARCHAR(128),
-    feedback VARCHAR(128),
-    Images VARCHAR(128)[],
-    Videos VARCHAR(128)[]
-    )`,
-  dropRecordsTableQuery: () => 'DROP TABLE IF EXISTS records',
+  addAdminQuery: () => `INSERT INTO 
+  users(email,firstname,lastname,othername,password,phone_number,registered,username,is_admin)
+  VALUES($1,$2,$3,$4,$5,$6,$7,$8,true)
+  returning *`,
 
   getAllRecordsByTypeQuery: () => `SELECT * from records 
   WHERE is_active=true and type=$1`,

--- a/server/test/intervention.spec.js
+++ b/server/test/intervention.spec.js
@@ -760,7 +760,7 @@ describe('Attempt to update intervention record status', () => {
 
   it('should fail if new status is not valid', (done) => {
     const updatedRecord = {
-      status: 3334,
+      status: 'in limbo',
     };
     chai.request(app)
       .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId}/status`)

--- a/server/test/intervention.spec.js
+++ b/server/test/intervention.spec.js
@@ -676,3 +676,150 @@ describe('Attempt to get all intervention records', () => {
       });
   });
 });
+
+describe('Attempt to update intervention record status', () => {
+  let recentlyAddedRecordId;
+  let adminToken;
+  before((done) => {
+    const newRecord = {
+      comment: 'Bob Dylan is Stealing Money',
+    };
+    chai.request(app)
+      .post(`${currApiPrefix}/interventions`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(newRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(200);
+        recentlyAddedRecordId = res.body.data[0].id;
+        const AdminUser = {
+          email: 'admin@yahoo.com',
+          password: 'baddestadmineverliveth',
+        };
+        chai.request(app)
+          .post(`${currApiPrefix}/auth/login`)
+          .send(AdminUser)
+          .end((error, response) => {
+            should.not.exist(error);
+            adminToken = response.body.data[0].token;
+            done();
+          });
+      });
+  });
+
+  it('should succeed if request is made by admin', (done) => {
+    const modifiedRecord = {
+      status: 'under investigation',
+      feedback: 'Investigation will begin on monday morning',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(modifiedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(200);
+        expect(res.body.data[0].message).to.equal('Updated red-flag record’s status to under investigation');
+        expect(res.body.data[0].updatedRecord.status).to.equal(modifiedRecord.status);
+        expect(res.body.data[0].updatedRecord.feedback).to.equal(modifiedRecord.feedback);
+        done();
+      });
+  });
+
+  it('should fail if request is made by owner of the record', (done) => {
+    const modifiedRecord = {
+      status: 'resolved',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(modifiedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(403);
+        expect(res.body.error).to.equal('You do not have permissions to update the status of this record');
+        done();
+      });
+  });
+
+  it('should fail if request is made by any other non admin', (done) => {
+    const updatedRecord = {
+      status: 'rejected',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(403);
+        expect(res.body.error).to.equal('You do not have permissions to update the status of this record');
+        done();
+      });
+  });
+
+  it('should fail if new status is not valid', (done) => {
+    const updatedRecord = {
+      status: 3334,
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error[0].status).to.equal('Invalid Status');
+        done();
+      });
+  });
+
+  it('should fail if new status is empty', (done) => {
+    const updatedRecord = {
+      status: ' ',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error[0].status).to.equal('Status is Required');
+        done();
+      });
+  });
+
+  it('should fail if feedback is invalid', (done) => {
+    const updatedRecord = {
+      status: 'resolved',
+      feedback: 6,
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error[0].feedback).to.equal('Invalid Feedback');
+        done();
+      });
+  });
+
+  it('should fail if record does not exist', (done) => {
+    const updatedRecord = {
+      status: 'resolved',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/interventions/${recentlyAddedRecordId + 778}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(404);
+        expect(res.body.error).to.equal('Record does not exist');
+        done();
+      });
+  });
+});

--- a/server/test/red-flag.spec.js
+++ b/server/test/red-flag.spec.js
@@ -676,3 +676,150 @@ describe('Attempt to get all red flag records', () => {
       });
   });
 });
+
+describe('Attempt to update red flag record status', () => {
+  let recentlyAddedRecordId;
+  let adminToken;
+  before((done) => {
+    const newRecord = {
+      comment: 'Bob Dylan is Stealing Money',
+    };
+    chai.request(app)
+      .post(`${currApiPrefix}/red-flags`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(newRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(200);
+        recentlyAddedRecordId = res.body.data[0].id;
+        const AdminUser = {
+          email: 'admin@yahoo.com',
+          password: 'baddestadmineverliveth',
+        };
+        chai.request(app)
+          .post(`${currApiPrefix}/auth/login`)
+          .send(AdminUser)
+          .end((error, response) => {
+            should.not.exist(error);
+            adminToken = response.body.data[0].token;
+            done();
+          });
+      });
+  });
+
+  it('should succeed if request is made by admin', (done) => {
+    const modifiedRecord = {
+      status: 'rejected',
+      feedback: 'not enough proof supplied to back your claim',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/red-flags/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(modifiedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(200);
+        expect(res.body.data[0].message).to.equal('Updated red-flag record’s status to rejected');
+        expect(res.body.data[0].updatedRecord.status).to.equal(modifiedRecord.status);
+        expect(res.body.data[0].updatedRecord.feedback).to.equal(modifiedRecord.feedback);
+        done();
+      });
+  });
+
+  it('should fail if request is made by owner of the record', (done) => {
+    const modifiedRecord = {
+      status: 'resolved',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/red-flags/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(modifiedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(403);
+        expect(res.body.error).to.equal('You do not have permissions to update the status of this record');
+        done();
+      });
+  });
+
+  it('should fail if request is made by any other non admin', (done) => {
+    const updatedRecord = {
+      status: 'rejected',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/red-flags/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(403);
+        expect(res.body.error).to.equal('You do not have permissions to update the status of this record');
+        done();
+      });
+  });
+
+  it('should fail if new status is not valid', (done) => {
+    const updatedRecord = {
+      status: 3334,
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/red-flags/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error[0].status).to.equal('Invalid Status');
+        done();
+      });
+  });
+
+  it('should fail if new status is empty', (done) => {
+    const updatedRecord = {
+      status: ' ',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/red-flags/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error[0].status).to.equal('Status is Required');
+        done();
+      });
+  });
+
+  it('should fail if feedback is invalid', (done) => {
+    const updatedRecord = {
+      status: 'resolved',
+      feedback: 6,
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/red-flags/${recentlyAddedRecordId}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error[0].feedback).to.equal('Invalid Feedback');
+        done();
+      });
+  });
+
+  it('should fail if record does not exist', (done) => {
+    const updatedRecord = {
+      status: 'resolved',
+    };
+    chai.request(app)
+      .patch(`${currApiPrefix}/red-flags/${recentlyAddedRecordId + 778}/status`)
+      .set('authorization', `Bearer ${rightUserToken}`)
+      .send(updatedRecord)
+      .end((err, res) => {
+        should.not.exist(err);
+        expect(res.body.status).to.equal(404);
+        expect(res.body.error).to.equal('Record does not exist');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- Add Api for admin operations with Intervention and red flag records

#### Description of task to be completed
- Design Api for Updating Status of Intervention Record
- Design Api for Updating Status of Red Flag Record
- Add test suite for all endpoints
- Change dropping table at beginning of test run to deleting emails used in Test instead
- Add validation for Status and Feedback
- Remove unessential queries from queries file

#### How should this be manually tested
- Clone the repository
- Checkout into the ```ft-update-status-API-162532293``` branch
- Install all dependencies
- Run ```npm run dev``` to start server in development mode
- Submit post request to /api/v1/login with 'admin@yahoo.com' as email and 'baddestadmineverliveth'  as password to get admin token 
- Submit POST requests to either ```/api/vi/interventions/:id/status``` or ```/api/vi/red-flags/:id/status``` with one of the four acceptible strings (pending review, under investigation, rejected, resolved) as the status then attach token gotten above to request header in the format ``` "authorization": `Bearer ${token}` ``` to see the returned updated record's status change to string passed

#### What are the relevant pivotal tracker stories 
- #162532293